### PR TITLE
Fix typo in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm install astro-broken-links-checker
 Finally, update your `astro.config.mjs`
 ```js
 import { defineConfig } from 'astro/config';
-import astroBrokenLinksChecker from 'astro-broken-link-checker';
+import astroBrokenLinksChecker from 'astro-broken-links-checker';
 
 export default defineConfig({
   // ... other configurations ...

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "astro-broken-links-checker",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "astro-broken-links-checker",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "Apache-2.0",
       "dependencies": {
         "fast-glob": "^3.3.3",
@@ -17,6 +17,9 @@
       "devDependencies": {
         "execa": "^9.6.1",
         "vitest": "^4.0.16"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-broken-links-checker",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "An Astro integration to check for broken links in your website during development and build time.",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
Currently the import mentioned in `README.md` does not work. This PR fixes the issue.

**Note**: The npm package is named `astro-broken-links-checker`, while the repo name is `astro-broken-link-checker` (link in singular). This looks unfortunate to me. I would consider renaming the repo name to make naming consistent. I leave this decision up to you.