### PR TITLE
Coalesce same URL checks into a single fetch

### DIFF
--- a/check-links.js
+++ b/check-links.js
@@ -114,12 +114,19 @@ export async function checkLinksInHtml(
       }
 
       if (checkedLinks.has(fetchLink)) {
-        const isBroken = !checkedLinks.get(fetchLink);
-        if (isBroken) {
+        const isValid = await checkedLinks.get(fetchLink);
+        if (!isValid) {
           addBrokenLink(brokenLinksMap, documentPath, link, distPath);
         }
         return;
       }
+
+      // Store an in-flight promise so concurrent checks for the same URL
+      // coalesce onto a single fetch rather than each issuing their own request.
+      let resolveCheck;
+      const checkPromise = new Promise((resolve) => { resolveCheck = resolve; });
+      checkedLinks.set(fetchLink, checkPromise);
+      checkedLinks.set(absoluteLink, checkPromise);
 
       let isBroken = false;
 
@@ -200,9 +207,7 @@ export async function checkLinksInHtml(
         }
       }
 
-      // Cache the link's validity
-      checkedLinks.set(fetchLink, !isBroken);
-      checkedLinks.set(absoluteLink, !isBroken);
+      resolveCheck(!isBroken);
 
       if (isBroken) {
         addBrokenLink(brokenLinksMap, documentPath, link, distPath);


### PR DESCRIPTION
On one of my sites, a lot of pages link to the same outbound URL and so we'd repeatedly spam query that URL. This coalesces exact-match URLs into a single fetch by making `checkedLinks` use promises. Cheers!